### PR TITLE
Virtual Camera test scene updates

### DIFF
--- a/scenes/2,22-virtual-cameras/package.json
+++ b/scenes/2,22-virtual-cameras/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@dcl/asset-packs": "^1.20.0",
     "@dcl/js-runtime": "7.5.7-10475279888.commit-6fa1fa3",
-    "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/camera-control-components/dcl-sdk-7.5.7-10568606923.commit-917522d.tgz"
+    "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/camera-control-components/dcl-sdk-7.5.8-10777537467.commit-84fb999.tgz"
   },
   "engines": {
     "node": ">=16.0.0",

--- a/scenes/2,22-virtual-cameras/package.json
+++ b/scenes/2,22-virtual-cameras/package.json
@@ -11,8 +11,8 @@
   },
   "devDependencies": {
     "@dcl/asset-packs": "^1.20.0",
-    "@dcl/js-runtime": "7.5.7-10475279888.commit-6fa1fa3",
-    "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/camera-control-components/dcl-sdk-7.5.8-10777537467.commit-84fb999.tgz"
+    "@dcl/js-runtime": "7.5.8-10777738407.commit-ecf90a0",
+    "@dcl/sdk": "^7.5.8-10777738407.commit-ecf90a0"
   },
   "engines": {
     "node": ">=16.0.0",

--- a/scenes/2,22-virtual-cameras/src/controllableCamera.ts
+++ b/scenes/2,22-virtual-cameras/src/controllableCamera.ts
@@ -1,4 +1,3 @@
-import { movePlayerTo } from '~system/RestrictedActions'
 import { Vector3, Quaternion, Color4 } from '@dcl/sdk/math'
 import { engine,
     Transform,
@@ -11,72 +10,19 @@ import { engine,
     inputSystem,
     PointerEventType,
     Material,
-    VisibilityComponent,
+    InputModifier
 } from '@dcl/sdk/ecs'
 
-// TODO: Replace all the "character movement confinement" logic with the new input freeze whenever it's released...
-
-// Character movement confinement setup (until player input freeze component is there)
-const characterPrisonPos = Vector3.create(14.5, 0.5, 14.5)
-const characterPrison = engine.addEntity()
-Transform.create(characterPrison, {
-    position: characterPrisonPos,
-})
-VisibilityComponent.create(characterPrison, { visible: false })
-const characterPrisonWall1 = engine.addEntity()
-Transform.create(characterPrisonWall1, {
-    position: Vector3.create(0, 1, 1),
-    scale: Vector3.create(1.5, 3, 0.25),
-    parent: characterPrison
-})
-MeshRenderer.setBox(characterPrisonWall1)
-Material.setBasicMaterial(characterPrisonWall1, { diffuseColor: Color4.Black() })
-VisibilityComponent.create(characterPrisonWall1, { visible: false })
-const characterPrisonWall2 = engine.addEntity()
-Transform.create(characterPrisonWall2, {
-    position: Vector3.create(0, 1, -1),
-    scale: Vector3.create(1.5, 3, 0.25),
-    parent: characterPrison
-})
-MeshRenderer.setBox(characterPrisonWall2)
-Material.setBasicMaterial(characterPrisonWall2, { diffuseColor: Color4.Black() })
-VisibilityComponent.create(characterPrisonWall2, { visible: false })
-const characterPrisonWall3 = engine.addEntity()
-Transform.create(characterPrisonWall3, {
-    position: Vector3.create(1, 1, 0),
-    scale: Vector3.create(0.25, 3, 1.5),
-    parent: characterPrison
-})
-MeshRenderer.setBox(characterPrisonWall3)
-Material.setBasicMaterial(characterPrisonWall3, { diffuseColor: Color4.Black() })
-VisibilityComponent.create(characterPrisonWall3, { visible: false })
-const characterPrisonWall4 = engine.addEntity()
-Transform.create(characterPrisonWall4, {
-    position: Vector3.create(-1, 1, 0),
-    scale: Vector3.create(0.25, 3, 1.5),
-    parent: characterPrison
-})
-MeshRenderer.setBox(characterPrisonWall4)
-Material.setBasicMaterial(characterPrisonWall4, { diffuseColor: Color4.Black() })
-VisibilityComponent.create(characterPrisonWall4, { visible: false })
-
-function ToggleCharacterPrison(enabled: boolean) {
-    if (enabled) {    
-        MeshCollider.setBox(characterPrisonWall1)
-        MeshCollider.setBox(characterPrisonWall2)
-        MeshCollider.setBox(characterPrisonWall3)
-        MeshCollider.setBox(characterPrisonWall4)
-    } else {
-        MeshCollider.deleteFrom(characterPrisonWall1)
-        MeshCollider.deleteFrom(characterPrisonWall2)
-        MeshCollider.deleteFrom(characterPrisonWall3)
-        MeshCollider.deleteFrom(characterPrisonWall4)
+InputModifier.create(engine.PlayerEntity)
+function ToggleCharacterInput(enabled: boolean) {
+    InputModifier.getMutable(engine.PlayerEntity).mode = {
+        $case: 'standard',
+        standard: {
+            disableWalk: !enabled,
+            disableRun: !enabled,
+            disableJog: !enabled,
+        }
     }
-    
-    VisibilityComponent.getMutable(characterPrisonWall1).visible = enabled
-    VisibilityComponent.getMutable(characterPrisonWall2).visible = enabled
-    VisibilityComponent.getMutable(characterPrisonWall3).visible = enabled
-    VisibilityComponent.getMutable(characterPrisonWall4).visible = enabled
 }
 
 // Controllable camera setup
@@ -104,9 +50,8 @@ export function InstantiateControllableCamera() {
         () => {
             const mainCamera = MainCamera.getMutableOrNull(engine.CameraEntity)
             if (!mainCamera) return
-            
-            ToggleCharacterPrison(true)
-            movePlayerTo({ newRelativePosition: characterPrisonPos })
+
+            ToggleCharacterInput(true)
             
             controllableCameraIsActive = true
             mainCamera.virtualCameraEntity = controllableCameraEntity
@@ -124,10 +69,9 @@ export function InstantiateControllableCamera() {
         const cameraForward = Vector3.Forward()
         Vector3.rotateToRef(cameraForward, cameraTransform.rotation, cameraForward)
         const cameraLeft = Vector3.rotate(cameraForward, Quaternion.fromEulerDegrees(0, -90, 0))
-
+        
         if (inputSystem.isTriggered(InputAction.IA_JUMP, PointerEventType.PET_DOWN)) {
-            movePlayerTo({ newRelativePosition: Vector3.create(8, 0.5, 6) })
-            ToggleCharacterPrison(false)            
+            ToggleCharacterInput(false)
             controllableCameraIsActive = false
             mainCamera.virtualCameraEntity = 0
         } else if (inputSystem.isPressed(InputAction.IA_FORWARD)) {

--- a/scenes/2,22-virtual-cameras/src/controllableCamera.ts
+++ b/scenes/2,22-virtual-cameras/src/controllableCamera.ts
@@ -90,7 +90,7 @@ export function InstantiateControllableCamera() {
     MeshCollider.setBox(controllableCameraEntity)
     Material.setBasicMaterial(controllableCameraEntity, { diffuseColor: Color4.Green() })
     VirtualCamera.create(controllableCameraEntity, {
-        defaultTransition: { transitionMode: { $case: "time", time: 0 } }
+        defaultTransition: { transitionMode: VirtualCamera.Transition.Time(0) }
     })
     pointerEventsSystem.onPointerDown(
         {

--- a/scenes/2,22-virtual-cameras/src/globalInputCameras.ts
+++ b/scenes/2,22-virtual-cameras/src/globalInputCameras.ts
@@ -37,7 +37,7 @@ export function InstantiateGlobalInputCameras() {
         position: Vector3.create(8, 16, 8),
         rotation: Quaternion.fromEulerDegrees(89, 0, 0)
     }, {
-        defaultTransition: { transitionMode: { $case: "time", time: 0 } }
+        defaultTransition: { transitionMode: VirtualCamera.Transition.Time(0) }
     }, "1")
 
     const staticVirtualCamera2Pos = Vector3.create(0, 16, 15)
@@ -45,7 +45,7 @@ export function InstantiateGlobalInputCameras() {
         position: staticVirtualCamera2Pos,
         rotation: Quaternion.fromLookAt(staticVirtualCamera2Pos, centerOfScenePosition)
     }, {
-        defaultTransition: { transitionMode: { $case: "time", time: 2 } }
+        defaultTransition: { transitionMode: VirtualCamera.Transition.Time(2) }
     }, "2")
 
     const staticVirtualCamera3Pos = Vector3.create(15, 16, 0)
@@ -53,7 +53,7 @@ export function InstantiateGlobalInputCameras() {
         position: staticVirtualCamera3Pos,
         rotation: Quaternion.fromLookAt(staticVirtualCamera3Pos, centerOfScenePosition)
     }, {
-        defaultTransition: { transitionMode: { $case: "speed", speed: 20 } },
+        defaultTransition: { transitionMode: VirtualCamera.Transition.Speed(20) },
         lookAtEntity: engine.PlayerEntity
     }, "3")
 
@@ -61,8 +61,7 @@ export function InstantiateGlobalInputCameras() {
         position: Vector3.create(2, 16, 2),
         rotation: Quaternion.fromEulerDegrees(89, 0, 0)
     }, {
-        // defaultTransition: { transitionMode: { $case: "speed", speed: 10 } }, // 10 meters per second
-        defaultTransition: { transitionMode: { $case: "speed", speed: 0 } },
+        defaultTransition: { transitionMode: VirtualCamera.Transition.Speed(0) },
         lookAtEntity: sceneCenterEntity
     }, "4")    
     Tween.create(movingVirtualCamera, {

--- a/scenes/2,22-virtual-cameras/src/globalInputCameras.ts
+++ b/scenes/2,22-virtual-cameras/src/globalInputCameras.ts
@@ -112,11 +112,12 @@ export function InstantiateGlobalInputCameras() {
             const mainCamera = MainCamera.getMutableOrNull(engine.CameraEntity)
             if (!mainCamera) return
             
-            // const currentVCam = VirtualCamera.getMutableOrNull(mainCamera.virtualCameraEntity as Entity)
-            // if (currentVCam && currentVCam.lookAtEntity) {
-            //   currentVCam.lookAtEntity = undefined;
-            //   return
-            // }
+            // To test changing the LookAt of an active Virtual Cam.
+            /*const currentVCam = VirtualCamera.getMutableOrNull(mainCamera.virtualCameraEntity as Entity)
+            if (currentVCam && currentVCam.lookAtEntity) {
+              currentVCam.lookAtEntity = undefined;
+              return
+            }*/
             
             const visibility = VisibilityComponent.getMutableOrNull(virtualCamerasCollection[currentVirtualCameraIndex])
             if (visibility) {


### PR DESCRIPTION
Continues updating the virtual camera component test scene added at https://github.com/decentraland/sdk7-test-scenes/pull/13.

* Updated sdk package to use `@next`
* Updated `oneof` cases with the new `VirtualCamera.Transition` helpers
* Replaced "character confinement" implementation for the new `InputModifier` for controllable camera, but left it disabled because the feature is bugged in the E@.